### PR TITLE
[BFS 1주차] jaeung

### DIFF
--- a/boj/silver/나이트의_이동/jaeung.js
+++ b/boj/silver/나이트의_이동/jaeung.js
@@ -1,0 +1,57 @@
+const getInput = () => {
+  const fs = require("fs");
+  const input = fs.readFileSync("dev/stdin").toString().trim().split("\r\n");
+
+  return input.map((str) => str.split(" ").map(Number));
+};
+
+const solution = (N, TC) => {
+  const answer = [];
+
+  for (let i = 0; i < N * 3; i += 3) {
+    const [[sideLength], [startX, startY], [endX, endY]] = TC.slice(i, i + 3);
+    answer.push(bfs(sideLength, startX, startY, endX, endY));
+  }
+
+  answer.forEach((num) => console.log(num));
+};
+
+const bfs = (sideLength, startX, startY, endX, endY) => {
+  const chessboard = Array.from(Array(sideLength), () =>
+    Array(sideLength).fill(0)
+  );
+  const dx = [-2, -1, 1, 2, 2, 1, -1, -2];
+  const dy = [1, 2, 2, 1, -1, -2, -2, -1];
+  const queue = [];
+
+  queue.push([startX, startY, 0]);
+  chessboard[startX][startY] = 1;
+
+  while (queue.length > 0) {
+    const [currentX, currentY, depth] = queue.shift();
+    const isEnd = endX === currentX && endY === currentY;
+
+    if (isEnd) return depth;
+
+    dx.forEach((_, index) => {
+      const nx = dx[index] + currentX;
+      const ny = dy[index] + currentY;
+
+      if (isBound(nx, ny, sideLength) && chessboard[nx][ny] === 0) {
+        queue.push([nx, ny, depth + 1]);
+        chessboard[nx][ny] = 1;
+      }
+    });
+  }
+
+  return 0;
+};
+
+const isBound = (x, y, sideLength) => {
+  if (x < sideLength && y < sideLength && x >= 0 && y >= 0) return true;
+
+  return false;
+};
+
+const [[N], ...TC] = getInput();
+solution(N, TC);

--- a/boj/silver/바이러스/jaeung.js
+++ b/boj/silver/바이러스/jaeung.js
@@ -1,0 +1,35 @@
+const fs = require("fs");
+const input = fs.readFileSync("dev/stdin").toString().trim().split("\r\n");
+
+const [[PCs], [_], ...linkedComputers] = input.map((arr) =>
+  arr.split(" ").map(Number)
+);
+
+const network = Array.from(Array(PCs + 1), () => Array(PCs + 1).fill(0));
+const visited = new Array(PCs + 1).fill(false);
+const queue = [];
+let count = 0;
+
+queue.push(1);
+visited[1] = true;
+
+linkedComputers.forEach(([pcA, pcB]) => {
+  network[pcA][pcB] = 1;
+  network[pcB][pcA] = 1;
+});
+
+while (queue.length > 0) {
+  const computer = queue.shift();
+
+  network[computer].forEach((c, index) => {
+    const isLinked = c === 1 && !visited[index];
+
+    if (isLinked) {
+      queue.push(index);
+      visited[index] = true;
+      count++;
+    }
+  });
+}
+
+console.log(count);

--- a/boj/silver/촌수계산/jaeung.js
+++ b/boj/silver/촌수계산/jaeung.js
@@ -1,11 +1,11 @@
-function getInput() {
+const getInput = () => {
   const fs = require("fs");
   const input = fs.readFileSync("dev/stdin").toString().trim().split("\r\n");
 
   return input.map((str) => str.split(" ").map(Number));
-}
+};
 
-function solution(N, startNumber, endNumber, relations) {
+const solution = (N, startNumber, endNumber, relations) => {
   const familyTrees = Array.from(Array(N + 1), () => Array(N + 1).fill(0));
 
   relations.forEach(([start, end]) => {
@@ -14,9 +14,9 @@ function solution(N, startNumber, endNumber, relations) {
   });
 
   console.log(bfs(startNumber, endNumber, familyTrees));
-}
+};
 
-function bfs(startNumber, endNumber, familyTrees) {
+const bfs = (startNumber, endNumber, familyTrees) => {
   const visited = Array(N + 1).fill(false);
   const queue = [];
 
@@ -39,7 +39,7 @@ function bfs(startNumber, endNumber, familyTrees) {
   }
 
   return -1;
-}
+};
 
 const [[N], [startNumber, endNumber], _, ...relations] = getInput();
 solution(N, startNumber, endNumber, relations);

--- a/boj/silver/촌수계산/jaeung.js
+++ b/boj/silver/촌수계산/jaeung.js
@@ -1,0 +1,45 @@
+function getInput() {
+  const fs = require("fs");
+  const input = fs.readFileSync("dev/stdin").toString().trim().split("\r\n");
+
+  return input.map((str) => str.split(" ").map(Number));
+}
+
+function solution(N, startNumber, endNumber, relations) {
+  const familyTrees = Array.from(Array(N + 1), () => Array(N + 1).fill(0));
+
+  relations.forEach(([start, end]) => {
+    familyTrees[start][end] = 1;
+    familyTrees[end][start] = 1;
+  });
+
+  console.log(bfs(startNumber, endNumber, familyTrees));
+}
+
+function bfs(startNumber, endNumber, familyTrees) {
+  const visited = Array(N + 1).fill(false);
+  const queue = [];
+
+  queue.push([startNumber, 0]);
+  visited[startNumber] = true;
+
+  while (queue.length > 0) {
+    const [people, depth] = queue.shift();
+
+    if (people === endNumber) return depth;
+
+    familyTrees[people].forEach((value, index) => {
+      const isVisited = value === 1 && !visited[index];
+
+      if (isVisited) {
+        queue.push([index, depth + 1]);
+        visited[index] = true;
+      }
+    });
+  }
+
+  return -1;
+}
+
+const [[N], [startNumber, endNumber], _, ...relations] = getInput();
+solution(N, startNumber, endNumber, relations);


### PR DESCRIPTION
# 코드 리뷰 진행에 앞서..

평소 코드를 작성할 때, 항상 읽기 좋은 코드를 작성하려고 고민을 많이 하고 있습니다.

그래서 이번에는 기존 방식의 코드(바이러스)와, 각 로직을 함수로 분리한 코드(촌수계산, 나이트의 이동)로 나누어서 작성해 보았는데, **어떤 코드가 흐름을 파악하기 좀 더 편하셨는지** 코멘트에 남겨주시면 감사하겠습니다! 🙇‍♂️

<br><br><br><br>

# 문제 출처 💻

[바이러스](https://www.acmicpc.net/problem/2606)

# 소요 시간 ⏱

30m

# 문제 접근 방법 🤔

- 네트워크 연결 상태를 인접 행렬 `network`로 나타내고, 탐색하는 방향으로 접근

- 모든 배열은 PC 번호를 파악하기 쉽도록, 입력 크기에서 1을 더한 만큼 길이를 늘림

- PC 방문 정보는 1차원 배열 `visited`에 저장하고, PC 개수를 기억할 `count` 변수를 선언

- 바이러스의 숙주가 되는 PC 1번을  `queue`에 삽입하고, `visited[1] = true`로 변경

- `queue`에서 하나씩 꺼내어 연결 상태와 방문 정보를 확인, 문제가 없다면 `queue`에 해당 `pc`를 추가하고, `visited[pcNumber] = true`, `count`를 증가시킨다.

- 이후 `count`를 반환하여 해결

<br><br><br><br>

# 문제 출처 💻

[촌수계산](https://www.acmicpc.net/problem/2644)

# 소요 시간 ⏱

30m

# 문제 접근 방법 🤔

- 바이러스 문제와 크게 다를 것은 없으나, **탐색 깊이를 확인하는 조건**이 추가된 것을 확인

- `DFS`로 푸는 것이 적절해 보였으나, 이번 주 주제를 생각해서 `BFS`로 풀이

- 바이러스와 마찬가지로 인접 행렬과, 1차원 배열 `visited`를 이용해서 접근

- `queue`에 사람 번호를 저장할 때, 해당 번호의 촌수를 확인하기 위해 `depth`를 추가하여 배열 형태로 저장

- 마찬가지로 `BFS` 탐색을 하고, 인접해있는 사람들은 이전 `depth + 1`을 해서 `queue`에 저장

- 이후 두 가지 상황에 따라 적절한 값을 반환하여 해결
  - `queue`에서 배열을 꺼냈을 때, 사람 번호와 타겟 번호가 일치한다면 `depth`를 반환
  - 끝까지 탐색을 마쳐도 일치하는 번호가 없는 경우(출발 노드와 도착 노드가 이어져있지 않는 경우), -1을 반환

<br><br><br><br>

# 문제 출처 💻

[나이트의 이동](https://www.acmicpc.net/problem/7562)

# 소요 시간 ⏱

50m

# 문제 접근 방법 🤔

- 마찬가지로 이전 문제와 크게 다를 것은 없지만, **나이트의 이동 경로**라는 조건이 추가된 것을 확인

- 이번에는 방문 정보가 노드의 번호가 아닌, 체스판에서의 좌표 정보가 필요하기 때문에, 방문 정보를 확인하는 배열을 2차원 배열로 선언

- 목적지에 도달하기 위한 나이트의 최소 이동 횟수를 계산하기 위해, `queue`에 `[x, y, depth]` 형태의 배열을 저장

- `BFS` 탐색을 진행하나, 나이트의 움직임에 따라 두 가지 로직을 추가
  - 나이트의 이동 경로를 표현한 적절한 배열 생성
  - 생성된 배열을 순회하며 `현재 위치 + 이동 경로`를 했을 때, 해당 좌표가 체스판의 크기를 넘어가지 않는지(유효한 좌표인지) 확인

- 촌수계산 문제와 동일하게 `queue`에서 배열을 꺼냈을 때, 현재 좌표와 도착 좌표가 동일하다면 `depth`를 반환하여 해결

