### PR TITLE
[BFS 1주차] minjong

### DIFF
--- a/boj/silver/나이트의_이동/minjong.js
+++ b/boj/silver/나이트의_이동/minjong.js
@@ -1,0 +1,38 @@
+// https://www.acmicpc.net/problem/7562
+
+const DX = [2, 1, -1, -2, -2, -1, 1, 2];
+const DY = [1, 2, 2, 1, -1, -2, -2, -1];
+
+const [[l], ...input] = require('fs').readFileSync('../../input.txt', 'utf-8').trim().split('\n').map((x) => x.split(' ').map(Number));
+
+function solution(l, departure, arrival) {
+  const board = Array.from({length: l}, () => new Array(l).fill(false));
+  const queue = [[...departure, 0]]
+
+  while (queue.length !== 0) {
+    const [x, y, count] = queue.shift();
+
+    if (!board[x][y]) {
+      board[x][y] = true;
+
+      if (x === arrival[0] && y == arrival[1]) return count
+
+      for (let i = 0; i < 8; i += 1) {
+        const nx = x + DX[i];
+        const ny = y + DY[i];
+        if ((nx >= 0 && nx < l && ny >= 0 && ny < l)) {
+          if (!board[nx][ny]) {
+            queue.push([nx, ny, count + 1]);
+          }
+        }
+      }
+    }
+  }
+
+}
+
+for (let i = 0; i < input.length / 3; i += 1) {
+  const sliceIndex = i * 3;
+  const [[l], departure, arrival] = input.slice(sliceIndex, sliceIndex + 3)
+  console.log(solution(l, departure, arrival));
+}

--- a/boj/silver/바이러스/minjong.js
+++ b/boj/silver/바이러스/minjong.js
@@ -1,0 +1,35 @@
+// https://www.acmicpc.net/problem/2606
+
+const [[c], [n], ...lines] = require('fs').readFileSync('../../input.txt', 'utf-8').trim().split('\n').map((x) => x.split(' ').map(Number));
+
+function solution(c, n, lines) {
+  let count = 0;
+  const graph = Array.from({ length: c + 1 }, () => []);
+  const visited = new Array(c + 1).fill(false);
+
+  for (const [src, dst] of lines) {
+    graph[src].push(dst);
+    graph[dst].push(src);
+  }
+
+  const queue = [1];
+
+  while (queue.length !== 0) {
+    const src = queue.shift();
+
+    if (!visited[src]) {
+      visited[src] = true;
+      count += 1;
+
+      for (const dst of graph[src]) {
+        if (!visited[dst]) {
+          queue.push(dst);
+        }
+      }
+    }
+  }
+
+  return count - 1;
+}
+
+console.log(solution(c, n, lines));

--- a/boj/silver/촌수_계산/minjong.js
+++ b/boj/silver/촌수_계산/minjong.js
@@ -1,0 +1,33 @@
+const [[n], targets, [m], ...relationships] = require('fs').readFileSync('../../input.txt', 'utf-8').trim().split('\n').map((x) => x.split(' ').map(Number));
+
+function solution(n, targets, m, relationships) {
+  const graph = Array.from({ length: n + 1 }, () => []);
+  const visited = new Array(n + 1).fill(false);
+
+  for (const [src, dst] of relationships) {
+    graph[src].push(dst);
+    graph[dst].push(src);
+  }
+
+  const queue = [[targets[0], 0]];
+
+  while (queue.length !== 0) {
+    const [src, count] = queue.shift();
+
+    if (!visited[src]) {
+      visited[src] = true;
+
+      if (src === targets[1]) return count;
+
+      for (const dst of graph[src]) {
+        if (!visited[dst]) {
+          queue.push([dst, count + 1]);
+        }
+      }
+    }
+  }
+
+  return -1;
+};
+
+console.log(solution(n, targets, m, relationships));


### PR DESCRIPTION
# 문제 출처 💻

[바이러스](https://www.acmicpc.net/problem/2606)

# 소요 시간 ⏱

20min

# 문제 접근 방법 🤔

* 컴퓨터의 연결을 `graph`로 표현
  * 두 컴퓨터를 연결하는 간선은 양방향이므로 출발, 도착지를 바꿔서 배열에 삽입
* 컴퓨터 탐색 기록을 저장하기 위한 `visited` 배열 선언
* 감염 컴퓨터 수를 확인할 `count` 선언
* 너비 탐색에 사용할 배열 `queue` 선언 후, 탐색을 시작할 컴퓨터인 1을 원소를 갖는 배열 대입
* `queue`가 아무런 원소를 갖지 않을 때 까지 반복
  * `queue`의 맨 앞 요소를 꺼내서 컴퓨터를 확인
  * 이미 탐색한 컴퓨터가 아니라면 `count += 1`
  * 탐색을 시작할 컴퓨터와 연결되어 있고, 방문하지 않은 도착 컴퓨터가 있는 경우 `queue`에 도착 컴퓨터를 삽입
* `count` 반환


# 문제 출처 💻

[촌수 계산](https://www.acmicpc.net/problem/2644)

# 소요 시간 ⏱

20min

# 문제 접근 방법 🤔

* 부모 자식간의 관계를 `graph`로 표현
  * 간선은 양방향이므로 부모, 자식을 바꿔서 배열에 삽입
* 탐색 기록을 저장하기 위한 `visited` 배열 선언
* 너비 탐색에 사용할 배열 `queue` 선언 후, 탐색을 시작할 변수와, 해당 정점까지의 이동 횟수를 표현할 `count`를 삽입
* `queue`가 아무런 원소를 갖지 않을 때 까지 반복
  * `queue`의 맨 앞 요소를 꺼내서 이동할 정점을 확인
  * 해당 정점이 목적지와 일치하는 경우 `count` 반환
  * 방문하지 않은 정점이 있는 경우 `queue`에 해당 정점과 `count + 1` 삽입
* 루프에서 반환 값이 없는 경우 -1을 반환


# 문제 출처 💻

[나이트의 이동](https://www.acmicpc.net/problem/7562)

# 소요 시간 ⏱

30min

# 문제 접근 방법 🤔

* 좌표를 이동할때 사용할 DX, DY 변수 선언
* `l x l` 배열 `board` 선언
* 너비 탐색에 사용할 배열 `queue` 선언 후, 탐색을 시작할 좌표와 이동한 횟수를 표현할 `count` 삽입
* `queue`가 아무런 원소를 갖지 않을 때 까지 반복
  * `queue`의 맨 앞 요소를 꺼내서 이동활 좌표를 확인
  * 방문하지 않은 경우 방문처리
  * 이동할 좌표가 도착지와 같다면 `count` 반환
  * 이동 가능한 모든 좌표를 계산
    * 이동할 좌표를 방문하지 않은 경우 `queue`에 해당 좌표와 `count + 1` 삽입