### PR TITLE
[BFS 2주차] minjong

### DIFF
--- a/boj/gold/아기_상어/minjong.js
+++ b/boj/gold/아기_상어/minjong.js
@@ -20,7 +20,7 @@ function solution(N, graph) {
   const queue = [[x, y, 0]];
   visited[x][y] = true;
 
-  while (queue.length > 0 && findFish(graph, sharkSize)) {
+  while (queue.length > 0) {
     sortQueue(queue);
     const [x, y, time] = queue.shift();
 
@@ -69,15 +69,6 @@ function findShark(graph) {
       if (graph[x][y] === 9) return [x, y];
     }
   }
-}
-
-function findFish(graph, sharkSize) {
-  for (let x = 0; x < graph.length; x += 1) {
-    for (let y = 0; y < graph[x].length; y += 1) {
-      if (graph[x][y] !== 0 && graph[x][y] < sharkSize) return true
-    }
-  }
-  return false;
 }
 
 console.log(solution(N, graph));

--- a/boj/gold/아기_상어/minjong.js
+++ b/boj/gold/아기_상어/minjong.js
@@ -1,0 +1,83 @@
+// https://www.acmicpc.net/problem/16236
+
+const [[N], ...graph] = require('fs')
+  .readFileSync(process.platform === 'linux' ? '/dev/stdin' : '../../input.txt', 'utf-8')
+  .split('\n')
+  .map(x => x.split(' ').map(Number));
+
+
+function solution(N, graph) {
+  const [x, y] = findShark(graph);
+  graph[x][y] = 0;
+
+  let sharkSize = 2;
+  let moveCount = 0;
+  let eatCount = 0;
+
+  const DX = [-1, 1, 0, 0];
+  const DY = [0, 0, 1, -1];
+  let visited = Array.from({ length: N }, () => Array(N).fill(false));
+  const queue = [[x, y, 0]];
+  visited[x][y] = true;
+
+  while (queue.length > 0 && findFish(graph, sharkSize)) {
+    sortQueue(queue);
+    const [x, y, time] = queue.shift();
+
+    if (graph[x][y] !== 0 && graph[x][y] < sharkSize) {
+      graph[x][y] = 0;
+      eatCount += 1;
+
+      if (eatCount === sharkSize) {
+        sharkSize += 1;
+        eatCount = 0;
+      }
+
+      visited = Array.from({ length: N }, () => Array(N).fill(false));
+      queue.splice(0);
+      moveCount = time;
+    }
+
+    for (let i = 0; i < DX.length; i += 1) {
+      const nx = x + DX[i];
+      const ny = y + DY[i];
+
+      if (nx >= 0 && nx < N && ny >= 0 & ny < N) {
+        if (!visited[nx][ny] && graph[nx][ny] <= sharkSize) {
+          visited[nx][ny] = true
+          queue.push([nx, ny, time + 1]);
+        }
+      }
+    }
+  }
+  return moveCount;
+}
+
+function sortQueue(queue) {
+  queue.sort((a, b) => {
+    if (a[2] === b[2]) {
+      if (a[0] === b[0]) return a[1] - b[1];
+      return a[0] - b[0]
+    }
+    return a[2] - b[2]
+  })
+}
+
+function findShark(graph) {
+  for (let x = 0; x < graph.length; x += 1) {
+    for (let y = 0; y < graph[x].length; y += 1) {
+      if (graph[x][y] === 9) return [x, y];
+    }
+  }
+}
+
+function findFish(graph, sharkSize) {
+  for (let x = 0; x < graph.length; x += 1) {
+    for (let y = 0; y < graph[x].length; y += 1) {
+      if (graph[x][y] !== 0 && graph[x][y] < sharkSize) return true
+    }
+  }
+  return false;
+}
+
+console.log(solution(N, graph));

--- a/boj/gold/적록색약/minjong.js
+++ b/boj/gold/적록색약/minjong.js
@@ -1,0 +1,52 @@
+// https://www.acmicpc.net/problem/10026
+
+const [N, ...rgb] = require('fs').readFileSync('../../input.txt', 'utf-8').trim().split('\n');
+
+function solution(N, nomRgb) {
+  let nomCount = 0;
+  let bldCount = 0;
+
+  const nomVisited = Array.from({ length: N }, () => Array(N).fill(false));
+  const bldVisited = Array.from({ length: N }, () => Array(N).fill(false));
+
+  const bldRgb = rgb.map(x => x.replaceAll("G", "R"));
+  for (let x = 0; x < rgb.length; x += 1) {
+    for (let y = 0; y < rgb[x].length; y += 1) {
+      if (!nomVisited[x][y]) {
+        nomCount += 1;
+        bfs(x, y, nomVisited, nomRgb);
+      }
+
+      if (!bldVisited[x][y]) {
+        bldCount += 1;
+        bfs(x, y, bldVisited, bldRgb);
+      }
+    }
+  }
+
+  return `${nomCount} ${bldCount}`
+}
+
+function bfs(x, y, visited, graph) {
+  const DX = [-1, 1, 0, 0];
+  const DY = [0, 0, 1, -1];
+  const queue = [[x, y]];
+
+  while (queue.length > 0) {
+    const [x, y] = queue.shift();
+
+    for (let i = 0; i < DX.length; i += 1) {
+      const nx = x + DX[i];
+      const ny = y + DY[i];
+
+      if (nx >= 0 && nx < graph.length && ny >= 0 && ny < graph[nx].length) {
+        if (!visited[nx][ny] && graph[x][y] === graph[nx][ny]) {
+          visited[nx][ny] = true;
+          queue.push([nx, ny]);
+        }
+      }
+    }
+  }
+}
+
+console.log(solution(Number(N), rgb));


### PR DESCRIPTION
# 문제 출처 💻

[적록색약](https://www.acmicpc.net/problem/10026)

# 소요 시간 ⏱

1h 30m

# 문제 접근 방법 🤔

* 색약인이 보는 그림은 초록색을 빨강색으로 변경, 문자 `R`을 `G`로 변경
* 일반인과 색약인이 보는 그림을 각각 BFS 탐색하며, 각각의 구역을 카운트
  * 현재 위치를 기준으로 상하좌우 좌표중 방문하지 않았고, 현재 위치의 색상과 동일한 좌표만 계속해서 탐색
* 카운트한 수를 반환

---

# 문제 출처 💻

[아기 상어](https://www.acmicpc.net/problem/16236)

# 소요 시간 ⏱

6h

# 문제 접근 방법 🤔

* 문제 조건 중, 상어가 물고기를 먹을 수 있는 조건과, 가장 가까운 물고기를 찾는 조건을 제대로 이해하지 못해 시간이 많이 소요됨.
<br>

* 탐색을 시작할 상어의 좌표를 찾고, 해당 좌표의 값을 0으로 변경
* 현재 상어 크기를 저장하는데 사용할 `sharkSize`, 상어가 움직인 횟수를 기록할 `moveCount`, 먹은 횟수를 기록한 `eatCount` 변수 선언
* BFS 탐색에 사용할 배열 `queue` 선언 후, `x좌표`, `y좌표`, `이동하는데 소요된 시간`을 삽입
* `queue`에 남은 요소가 없어질 때 까지 탐색
  * `queue`를 아래 우선순위에 맞게 정렬
    1. 거리가 제일 가까운 물고기
    2. 제일 위에 있는 물고기 (x좌표의 값이 적은 물고기)
    3. 제일 왼쪽에 있는 물고기 (y좌표의 값이 적은 물고기)
  * `queue`의 제일 첫 요소를 꺼내어 `x`, `y`, `time` 변수에 할당
  * `graph[x][y]` 물고기를 먹을 수 있는지 확인
    *  먹을 수 있다면 `eatCount`를 +1
      * `eatCount`와 `sharkSize`의 값이 같다면 `eatCount`를 0으로 초기화 후, `sharkSize`를 +1
      * 현재 위치를 기준으로 최적의 물고기 위치를 찾아야 하기 때문에 `queue`와 `visited`를 초기화
      * `moveCount`에 `time`을 대입
   * 상하좌우 좌표중 방문하지 않았고, 해당 좌표의 값이 `sharkSize`보다 적은 경우 `queue`에 삽입
 * `moveCount` 반환

> 예제 입력 3 탐색 순서 
> <img width="213" alt="image" src="https://user-images.githubusercontent.com/48359052/196031456-b3d9c2ac-d7a4-47d3-accd-d1b97e5a24f5.png">

---

# 문제 출처 💻

[구슬 탈출 2](https://www.acmicpc.net/problem/13460)

# 소요 시간 ⏱

--

# 문제 접근 방법 🤔

* 문제 접근 방법을 찾을 수 없어 해결하지 못했습니다. 역량을 키운 뒤 다시 도전해보면 좋을 것 같습니다. 🥲