### PR TITLE
[DFS 1주차] jaeung

### DIFF
--- a/boj/gold/트리/jaeung.js
+++ b/boj/gold/트리/jaeung.js
@@ -1,0 +1,52 @@
+const fs = require("fs");
+const input = fs.readFileSync("dev/stdin").toString().trim().split("\n");
+const [[N], links, [deleteNum]] = input.map((str) =>
+  str.split(" ").map(Number)
+);
+
+console.log(solution(N, links, deleteNum));
+
+function solution(N, links, deleteNum) {
+  const visited = Array(N).fill(false);
+  const tree = Array.from(Array(N), () => []);
+  const rootNode = links.indexOf(-1);
+  const stack = [rootNode];
+  let countLeafNode = 0;
+
+  if (rootNode === deleteNum) return 0;
+
+  visited[rootNode] = true;
+
+  for (let i = 0; i < N; i++) {
+    const node = links[i];
+    const isRoot = node === -1;
+    const isDeleteNode = node === deleteNum || i === deleteNum;
+
+    if (isRoot || isDeleteNode) continue;
+
+    tree[i].push(node);
+    tree[node].push(i);
+  }
+
+  loop: while (stack.length > 0) {
+    const peek = stack[stack.length - 1];
+    const isLeafNode =
+      (tree[peek].length === 1 && peek !== rootNode) || tree[peek].length === 0;
+
+    for (const node of tree[peek]) {
+      const isVisit = visited[node] === true;
+
+      if (!isVisit) {
+        stack.push(node);
+        visited[node] = true;
+        continue loop;
+      }
+    }
+
+    if (isLeafNode) countLeafNode++;
+
+    stack.pop();
+  }
+
+  return countLeafNode;
+}

--- a/boj/silver/나무_탈출/jaeung.js
+++ b/boj/silver/나무_탈출/jaeung.js
@@ -19,9 +19,14 @@ function solution(input) {
     nodes[b].push(a);
   }
 
-  loop: while (stack.length > 0) {
-    const [peek, depth] = stack[stack.length - 1];
-    const isLeafNode = nodes[peek].length === 1;
+  while (stack.length > 0) {
+    const [peek, depth] = stack.pop();
+    const isLeafNode = nodes[peek].length === 1 && peek !== 1;
+
+    if (isLeafNode) {
+      moveCount += depth;
+      continue;
+    }
 
     for (const node of nodes[peek]) {
       const isVisit = visited[node] === true;
@@ -29,15 +34,8 @@ function solution(input) {
       if (!isVisit) {
         stack.push([node, depth + 1]);
         visited[node] = true;
-        continue loop;
       }
     }
-
-    if (isLeafNode) {
-      moveCount += depth;
-    }
-
-    stack.pop();
   }
 
   const answer = moveCount % 2 === 0 ? "No" : "Yes";

--- a/boj/silver/나무_탈출/jaeung.js
+++ b/boj/silver/나무_탈출/jaeung.js
@@ -1,0 +1,47 @@
+const fs = require("fs");
+const input = fs.readFileSync("dev/stdin").toString().trim().split("\n");
+
+function solution(input) {
+  const N = +input[0];
+  const visited = Array(N + 1).fill(false);
+  const nodes = Array.from(Array(N + 1), () => []);
+  const stack = [[1, 0]];
+  let moveCount = 0;
+
+  visited[1] = true;
+
+  for (let i = 1; i < N; i++) {
+    const line = input[i].split(" ");
+    const a = +line[0];
+    const b = +line[1];
+
+    nodes[a].push(b);
+    nodes[b].push(a);
+  }
+
+  loop: while (stack.length > 0) {
+    const [peek, depth] = stack[stack.length - 1];
+    const isLeafNode = nodes[peek].length === 1;
+
+    for (const node of nodes[peek]) {
+      const isVisit = visited[node] === true;
+
+      if (!isVisit) {
+        stack.push([node, depth + 1]);
+        visited[node] = true;
+        continue loop;
+      }
+    }
+
+    if (isLeafNode) {
+      moveCount += depth;
+    }
+
+    stack.pop();
+  }
+
+  const answer = moveCount % 2 === 0 ? "No" : "Yes";
+  console.log(answer);
+}
+
+solution(input);

--- a/boj/silver/트리의_부모_찾기/jaeung.js
+++ b/boj/silver/트리의_부모_찾기/jaeung.js
@@ -1,0 +1,40 @@
+const fs = require("fs");
+const input = fs.readFileSync("dev/stdin").toString().trim().split("\n");
+const [[N], ...links] = input.map((str) => str.split(" ").map(Number));
+
+function solution(N, links) {
+  let str = "";
+  const answer = [];
+  const stack = [1];
+  const visited = Array(N + 1).fill(false);
+  const nodes = Array.from(Array(N + 1), () => []);
+
+  visited[1] = true;
+
+  links.forEach(([a, b]) => {
+    nodes[a].push(b);
+    nodes[b].push(a);
+  });
+
+  loop: while (stack.length > 0) {
+    const peek = stack[stack.length - 1];
+
+    for (const node of nodes[peek]) {
+      const isVisit = visited[node] === true;
+
+      if (!isVisit) {
+        visited[node] = true;
+        stack.push(node);
+        continue loop;
+      }
+    }
+
+    stack.pop();
+    answer[peek] = stack[stack.length - 1];
+  }
+
+  answer.slice(2).forEach((node) => (str += node + "\n"));
+  console.log(str);
+}
+
+solution(N, links);


### PR DESCRIPTION
# 문제 출처 💻

[트리의 부모 찾기](https://www.acmicpc.net/problem/11725)

# 소요 시간 ⏱

30m

# 문제 접근 방법 🤔

- 기본적인 `DFS` 문제로, `stack`을 이용한 구현으로 접근

- `input`이 100,000으로 굉장히 크기 때문에, 최적화를 위해 연결되어있는 노드의 정보를 인접 리스트 형식으로 저장

- 루트 노트(1)를 스택에 넣어 두고, 방문 여부를 `true`로 변경한 뒤, `DFS` 알고리즘을 이용해 노드를 순회

- 각 노드의 부모 노드를 저장할 `answer` 배열 선언

- 자식이 없는 노드(리프 노드) 혹은 더이상 방문할 노드가 없는 경우, 스택에서 해당 노드를 제거

- 이 때 스택에 남아있는 가장 마지막 요소가 제거된 노드의 부모 노드기 때문에, `answer[deleteNode] = stack[stack.length - 1]`로 노드 번호에 해당하는 인덱스에 부모 노드를 저장

- 이후 `answer` 배열을 순회하며 각 요소를 출력하면 해결되지만, 시간 초과로 실패

- 이유는 `console.log()`의 출력 횟수가 많을수록 성능이 떨어지기 때문. 해결책으로 부모 노드를 모두 하나의 문자열에 추가한 뒤, 한 번만 출력하여 해결

<br><br><br><br>

# 문제 출처 💻

[나무 탈출](https://www.acmicpc.net/problem/15900)

# 소요 시간 ⏱

2h+

# 문제 접근 방법 🤔

- 트리의 부모 찾기와 마찬가지로 기본적인 `DFS` 문제라고 생각, 동일하게 `stack`을 이용한 구현으로 접근

- 성능 최적화를 위해 모든 리프 노드의 깊이의 합이 홀수이면 `Yes`, 짝수이면 `No`를 출력하는 방식으로 구현

- `stack`에는 노드 번호와 깊이를 나타내는 `depth` 를 배열 형태로 추가하여, 새로운 노드가 추가될 때 마다 이전 `depth + 1`을 통해 현재 노드의 깊이를 알아냄

- 노드에 해당하는 인접리스트의 길이가 1인 경우 리프 노드라고 판단하고, `moveCount`에 `depth`를 더하는 식으로 접근

- 하지만 계속 시간 초과가 나왔고, `BFS`와 재귀를 이용한 코드로 수정해 보았으나 전부 시간 초과로 실패

- 다른 풀이를 참고하려 했으나 해당 문제의 `node.js` 정답이 아예 없는것을 확인

- 아마도 `input`이 매우 크기 때문에 **`string.split()` 메서드의 성능 문제로 실패하지 않았나 추측**, 실제로 입력을 받아오는 과정에서 고차 함수가 체이닝 되어있는 것을 분리해보니 1%에서 시간 초과가 발생하던 것이 11%에서 발생함.

- `depth`가 깊은 경우, `pop`을 `depth`만큼 하던 문제 때문에 시간 초과 발생, 리뷰 코멘트를 참고하여 문제 해결

<br><br><br><br>
# 문제 출처 💻

[트리](https://www.acmicpc.net/problem/1068)

# 소요 시간 ⏱

30m

# 문제 접근 방법 🤔

- 마찬가지로 기본적인 `DFS` 구현, 다만 몇 가지 조건이 추가된 것을 확인

- 특정 노드 제거는 해당 노드가 제거해야 할 노드인 경우, 아예 `tree`에 추가하지 않는 것으로 구현

- 이후 `DFS`로 트리를 순회하며, 리프 노드인 경우 `countLeafNode`를 1씩 증가
  - 리프 노드 판별 기준은 **해당 노드의 인접리스트 배열의 길이가 1이고, 해당 노드가 루트 노드가 아니거나**(`tree[peek].length === 1 && peek !== rootNode`), 혹은(`||`) **인접리스트 배열의 길이가 0인 경우**(루트를 포함한 노드가 단 2개일 경우 예외 처리)이다.

- 이후 루트 노드와 제거 노드가 동일한 경우, 모든 노드가 제거되므로 0을, 아니라면 `countLeafNode`를 반환하여 해결
