### PR TITLE
[DFS 1주차] minjong

### DIFF
--- a/boj/gold/트리/minjong.js
+++ b/boj/gold/트리/minjong.js
@@ -1,0 +1,49 @@
+const [[N], parentNodes, [removeNode]] = require('fs')
+  .readFileSync(process.platform === 'linux' ? '/dev/stdin' : '../../input.txt', 'utf-8')
+  .trim()
+  .split('\n')
+  .map(x => x.split(' ').map(Number));
+
+function solution(N, parentNodes, removeNode) {
+  const tree = Array.from({ length: N }, () => []);
+  const start = parentNodes.findIndex(x => x === -1);
+
+  if (start === removeNode) return 0;
+
+  parentNodes.forEach((parentNode, i) => {
+    if (parentNode !== -1 && parentNode !== removeNode && i !== removeNode) {
+      tree[parentNode].push(i);
+      tree[i].push(parentNode);
+    }
+  });
+
+  const visited = Array(N).fill(false);
+
+  return dfs(start, tree, visited);
+}
+
+function dfs (start, tree, visited) {
+  const stack = [start];
+  visited[start] = true;
+
+  let leafCount = 0;
+
+  while (stack.length !== 0) {
+    const src = stack.pop();
+
+    if ((src !== start && tree[src].length === 1) || tree[src].length === 0) {
+      leafCount += 1;
+      continue;
+    }
+
+    for (const dst of tree[src]) {
+      if (!visited[dst]) {
+        visited[dst] = true;
+        stack.push(dst);
+      }
+    }
+  }
+
+  return leafCount;
+}
+console.log(solution(N, parentNodes, removeNode));

--- a/boj/silver/나무_탈출/minjong.js
+++ b/boj/silver/나무_탈출/minjong.js
@@ -4,44 +4,44 @@ const [N, ...edge] = require('fs')
   .readFileSync(process.platform === 'linux' ? '/dev/stdin' : '../../input.txt', 'utf-8')
   .trim()
   .split('\n')
-  // .map(x => x.split(' ').map(Number));
+  .map(x => x.split(' ').map(Number));
 
 
 function solution(N, edge) {
   const tree = Array.from({ length: N + 1 }, () => []);
 
-  edge.forEach((x) => {
-    const [src, dst] = x.split(' ').map(Number);
+  edge.forEach(([src, dst]) => {
     tree[src].push(dst);
     tree[dst].push(src);
   });
 
   const visited = Array(N + 1).fill(false)
-  // const distance = Array(N + 1).fill(0);
 
   return dfs(1, tree, visited);
 }
 
-function dfs (src, tree, visited) {
-  const stack = [[src, 0]];
+function dfs(start, tree, visited) {
+  const stack = [[start, 0]];
+  visited[start] = true;
+  
   let leafDist = 0;
-  visited[src] = true;
 
   while (stack.length !== 0) {
     const [src, dist] = stack.pop();
 
+    if (src !== start && tree[src].length === 1) {
+      leafDist += dist;
+      continue;
+    }
+
     for (const dst of tree[src]) {
       if (!visited[dst]) {
         visited[dst] = true;
-        if (tree[dst].length === 1) leafDist += dist + 1;
         stack.push([dst, dist + 1]);
       }
     }
   }
-  // return (leafDist.reduce((acc, cur) => acc + cur) % 2 == 0 ? 'No' : 'Yes');
   return leafDist % 2 === 0 ? 'No' : 'Yes';
 }
-
-// console.log(+N, edge);
 
 console.log(solution(N, edge));

--- a/boj/silver/나무_탈출/minjong.js
+++ b/boj/silver/나무_탈출/minjong.js
@@ -1,0 +1,47 @@
+// 시간 초과
+
+const [N, ...edge] = require('fs')
+  .readFileSync(process.platform === 'linux' ? '/dev/stdin' : '../../input.txt', 'utf-8')
+  .trim()
+  .split('\n')
+  // .map(x => x.split(' ').map(Number));
+
+
+function solution(N, edge) {
+  const tree = Array.from({ length: N + 1 }, () => []);
+
+  edge.forEach((x) => {
+    const [src, dst] = x.split(' ').map(Number);
+    tree[src].push(dst);
+    tree[dst].push(src);
+  });
+
+  const visited = Array(N + 1).fill(false)
+  // const distance = Array(N + 1).fill(0);
+
+  return dfs(1, tree, visited);
+}
+
+function dfs (src, tree, visited) {
+  const stack = [[src, 0]];
+  let leafDist = 0;
+  visited[src] = true;
+
+  while (stack.length !== 0) {
+    const [src, dist] = stack.pop();
+
+    for (const dst of tree[src]) {
+      if (!visited[dst]) {
+        visited[dst] = true;
+        if (tree[dst].length === 1) leafDist += dist + 1;
+        stack.push([dst, dist + 1]);
+      }
+    }
+  }
+  // return (leafDist.reduce((acc, cur) => acc + cur) % 2 == 0 ? 'No' : 'Yes');
+  return leafDist % 2 === 0 ? 'No' : 'Yes';
+}
+
+// console.log(+N, edge);
+
+console.log(solution(N, edge));

--- a/boj/silver/나무_탈출/minjong.js
+++ b/boj/silver/나무_탈출/minjong.js
@@ -1,19 +1,20 @@
 // 시간 초과
 
-const [N, ...edge] = require('fs')
+const input = require('fs')
   .readFileSync(process.platform === 'linux' ? '/dev/stdin' : '../../input.txt', 'utf-8')
   .trim()
-  .split('\n')
-  .map(x => x.split(' ').map(Number));
+  .split('\n');
 
 
-function solution(N, edge) {
+function solution(input) {
+  const N = +input[0];
   const tree = Array.from({ length: N + 1 }, () => []);
 
-  edge.forEach(([src, dst]) => {
-    tree[src].push(dst);
-    tree[dst].push(src);
-  });
+  for (let i = 1; i< N; i += 1) {
+    const [src, dst] = input[i].split(' ');
+    tree[+src].push(+dst);
+    tree[+dst].push(+src);
+  };
 
   const visited = Array(N + 1).fill(false)
 
@@ -44,4 +45,4 @@ function dfs(start, tree, visited) {
   return leafDist % 2 === 0 ? 'No' : 'Yes';
 }
 
-console.log(solution(N, edge));
+console.log(solution(input));

--- a/boj/silver/트리의_부모_찾기/minjong.js
+++ b/boj/silver/트리의_부모_찾기/minjong.js
@@ -1,0 +1,39 @@
+const [[N], ...edge] = require('fs')
+  .readFileSync(process.platform === 'linux' ? '/dev/stdin' : '../../input.txt', 'utf-8')
+  .trim()
+  .split('\n')
+  .map(x => x.split(' ').map(Number));
+
+
+function solution(N, edge) {
+  const tree = Array.from({length: N + 1}, () => []);
+  
+  edge.forEach(([src, dst]) => {
+    tree[src].push(dst);
+    tree[dst].push(src);
+  });
+
+  const visited = Array(N + 1).fill(false)
+  const parents = Array(N + 1);
+
+  return dfs(1, tree, visited, parents);
+}
+
+function dfs(src, tree, visited, parents) {
+  const stack = [src];
+
+  while (stack.length !== 0) {
+    const src = stack.pop();
+    for (let dst of tree[src]) {
+      if (!visited[dst]) {
+        visited[dst] = true;
+        parents[dst] = src;
+        stack.push(dst);
+      }
+    }
+  }
+
+  return parents.slice(2).join('\n');
+}
+
+console.log(solution(N, edge));


### PR DESCRIPTION
그렇게 어렵지 않은 문제인데 문제를 잘못 해석해서 오래 걸린 것 같습니다. 😢 
문제를 꼼꼼히 읽는 습관을 길러야 겠습니다...

---

# 문제 출처 💻

[트리의 부모 찾기](https://www.acmicpc.net/problem/11725)

# 소요 시간 ⏱

30min

# 문제 접근 방법 🤔

* 일반적인 DFS 문제에 각 노드의 부모 노드를 기록
<Br>

* 주어진 정점을 연결 리스트로 표현하는 그래프 `tree` 선언
* 방문 기록을 저장할 배열 `visited` 선언
* 부모 노드 번호를 기록할 배열 `parents` 선언
* DFS 탐색
  * 탐색에 사용할 `stack`선언 후 `stack`의 요소가 없을 때 까지 반복
  * 현재 노드 `src`와 연결되어 있는 노드 중 방문하지 않은 노드 `dst`를 탐색
    * 해당 노드를 방문 처리 후 `stack`에 `push`
    * 해당 노드의 부모 노드를 `parent` 배열에 저장
* `parent` 배열의 3번째 요소부터 문자열로 합친 후 반환

---

# 문제 출처 💻

[나무 탈출](https://www.acmicpc.net/problem/15900)

# 소요 시간 ⏱

over 2h

# 문제 접근 방법 🤔

* 일반적인 DFS 문제에 리프 노드인지 판별하는 로직을 추가
  * 리프 노드를 구하는 로직을 찾았으나 어떻게 활용하여 문제를 풀 수 있는지 찾지 못해서 https://dhbang.tistory.com/30 풀이를 참고
  * 모든 루트에서 리프 노드 까지 거리의 합이 짝수이면 이길 수 없다는 것을 확인
<Br>

* 주어진 정점을 연결 리스트로 표현하는 그래프 `tree` 선언
* 방문 기록을 저장할 배열 `visited` 선언
* DFS 탐색
  * 탐색에 사용할 `stack`선언 후 현재 노드와 루트에서 현재 노드까지의 거리를 삽입
  * 리프 노드들의 거리를 저장할 `leafDist` 선언
  * `stack`의 요소가 없을 때 까지 반복
  * 현재 노드가 루트가 아니고, 인접 리스트의 길이가 1인 경우 (연결된 노드가 부모 하나인 경우) leafDist 에 현재 노드의 거리를 저장
  * 현재 노드 `src`와 연결되어 있는 노드 중 방문하지 않은 노드 `dst`를 탐색
    * 해당 노드를 방문 처리
    * `stack`에 해당 노드 `dst`와 현재 노드까지의 거리를 나타내는 `dist`에 +1을 하여 `push`
* leafDist 가 짝수이면 `No` 홀수면 `Yes` 출력

---

# 문제 출처 💻

[트리](https://www.acmicpc.net/problem/1068)

# 소요 시간 ⏱

over 2h

# 문제 접근 방법 🤔

* 일반적인 DFS 문제에 리프 노드인지 판별하는 로직을 추가
  * 시작이 항상 0번 째 노드일 거라는 생각과 리프 노드를 확인할 때 루트 노드 하나만 남는 경우를 고려하지 못해 시간이 많이 소요됨 
<Br>

* 주어진 정점을 연결 리스트로 표현하는 그래프 `tree` 선언
* `removeNode`는 연결하지 않음
* 방문 기록을 저장할 배열 `visited` 선언
* DFS 탐색
  * 탐색에 사용할 `stack` 선언
  * 리프 노드의 수를 카운팅할 `leafCount` 선언
  * `stack`의 요소가 없을 때 까지 반복
  * 현재 노드가 루트가 아니고, 인접 리스트의 길이가 1이거나 인접 리스트의 길이가 하나도 없는 경우 (연결된 노드가 부모 하나인 경우와 루트 노드 하나만 남는 경우) leafCount 를 +1
  * 현재 노드 `src`와 연결되어 있는 노드 중 방문하지 않은 노드 `dst`를 탐색
    * 해당 노드를 방문 처리 후 `stack`에 `push`
* `leafCount`를 반환