### PR TITLE
[DFS 2주차] jaeung

### DIFF
--- a/boj/gold/Two_Dots/jaeung.js
+++ b/boj/gold/Two_Dots/jaeung.js
@@ -1,0 +1,61 @@
+const fs = require("fs");
+const input = fs.readFileSync("dev/stdin").toString().trim().split("\n");
+const [N, M] = input.shift().split(" ").map(Number);
+const board = input.map((str) => str.split(""));
+
+console.log(solution(N, M, board));
+
+function solution(N, M, board) {
+  for (let x = 0; x < N; x++) {
+    for (let y = 0; y < M; y++) {
+      if (searchCycle(x, y, N, M, board)) return "Yes";
+    }
+  }
+
+  return "No";
+}
+
+function searchCycle(x, y, N, M, board) {
+  const stack = [[x, y]];
+  const visited = Array.from(Array(board.length), () =>
+    Array(board[0].length).fill(false)
+  );
+  const dx = [-1, 0, 1, 0];
+  const dy = [0, 1, 0, -1];
+
+  visited[x][y] = true;
+
+  loop: while (stack.length > 0) {
+    const [currentX, currentY] = stack[stack.length - 1];
+    const [startX, startY] = stack[0];
+
+    for (let i = 0; i < dx.length; i++) {
+      const nx = dx[i] + currentX;
+      const ny = dy[i] + currentY;
+      const isVisit = isBound(nx, ny, N, M) && visited[nx][ny] === true;
+      const isSameColor =
+        isBound(nx, ny, N, M) && board[currentX][currentY] === board[nx][ny];
+      const isCycle =
+        isBound(nx, ny, N, M) &&
+        nx === startX &&
+        ny === startY &&
+        stack.length >= 4;
+
+      if (!isVisit && isSameColor) {
+        stack.push([nx, ny]);
+        visited[nx][ny] = true;
+        continue loop;
+      }
+
+      if (isCycle) return true;
+    }
+
+    stack.pop();
+  }
+
+  return false;
+}
+
+function isBound(x, y, N, M) {
+  return x >= 0 && y >= 0 && x < N && y < M ? true : false;
+}

--- a/boj/gold/빵집/jaeung.js
+++ b/boj/gold/빵집/jaeung.js
@@ -1,5 +1,5 @@
 const fs = require("fs");
-const input = fs.readFileSync("dev/stdin").toString().trim().split("\r\n");
+const input = fs.readFileSync("dev/stdin").toString().trim().split("\n");
 const [R, C] = input.shift().split(" ").map(Number);
 const grids = input.map((str) => str.split(""));
 
@@ -18,31 +18,31 @@ function solution(R, C, grids) {
 
 function searchLine(x, visited, grids) {
   const stack = [[x, 0]];
-  const dx = [-1, 0, 1];
+  const dx = [1, 0, -1];
   const dy = [1, 1, 1];
 
   visited[x][0] = true;
 
-  loop: while (stack.length > 0) {
-    const [currentX, currentY] = stack[stack.length - 1];
+  while (stack.length > 0) {
+    const [currentX, currentY] = stack.pop();
     const isEnd = currentY === C - 1;
 
-    if (isEnd) return true;
+    if (isEnd) {
+      stack.forEach(([x, y]) => (visited[x][y] = false));
+      return true;
+    }
 
     for (let i = 0; i < dx.length; i++) {
       const nx = currentX + dx[i];
       const ny = currentY + dy[i];
-      const isVisit = isBound(nx, ny, R, C) && visited[nx][ny] === true;
-      const isEmpty = isBound(nx, ny, R, C) && grids[nx][ny] === ".";
+      const isVisit = isBound(nx, ny, R, C) && visited[nx][ny] === false;
+      const isBuilding = isBound(nx, ny, R, C) && grids[nx][ny] === "x";
 
-      if (!isVisit && isEmpty) {
+      if (isVisit && !isBuilding) {
         stack.push([nx, ny]);
         visited[nx][ny] = true;
-        continue loop;
       }
     }
-
-    stack.pop();
   }
 
   return false;

--- a/boj/gold/빵집/jaeung.js
+++ b/boj/gold/빵집/jaeung.js
@@ -10,13 +10,13 @@ function solution(R, C, grids) {
   let pipeCount = 0;
 
   for (let x = 0; x < R; x++) {
-    if (searchLine(x, visited, grids)) pipeCount++;
+    if (isPlumbing(x, visited, grids)) pipeCount++;
   }
 
   return pipeCount;
 }
 
-function searchLine(x, visited, grids) {
+function isPlumbing(x, visited, grids) {
   const stack = [[x, 0]];
   const dx = [1, 0, -1];
   const dy = [1, 1, 1];

--- a/boj/gold/빵집/jaeung.js
+++ b/boj/gold/빵집/jaeung.js
@@ -1,0 +1,55 @@
+const fs = require("fs");
+const input = fs.readFileSync("dev/stdin").toString().trim().split("\r\n");
+const [R, C] = input.shift().split(" ").map(Number);
+const grids = input.map((str) => str.split(""));
+
+console.log(solution(R, C, grids));
+
+function solution(R, C, grids) {
+  const visited = Array.from(Array(R), () => Array(C).fill(false));
+  let pipeCount = 0;
+
+  for (let x = 0; x < R; x++) {
+    if (searchLine(x, visited, grids)) pipeCount++;
+  }
+
+  return pipeCount;
+}
+
+function searchLine(x, visited, grids) {
+  const stack = [[x, 0]];
+  const dx = [-1, 0, 1];
+  const dy = [1, 1, 1];
+
+  visited[x][0] = true;
+
+  loop: while (stack.length > 0) {
+    const [currentX, currentY] = stack[stack.length - 1];
+    const isEnd = currentY === C - 1;
+
+    if (isEnd) return true;
+
+    for (let i = 0; i < dx.length; i++) {
+      const nx = currentX + dx[i];
+      const ny = currentY + dy[i];
+      const isVisit = isBound(nx, ny, R, C) && visited[nx][ny] === true;
+      const isEmpty = isBound(nx, ny, R, C) && grids[nx][ny] === ".";
+
+      if (!isVisit && isEmpty) {
+        stack.push([nx, ny]);
+        visited[nx][ny] = true;
+        continue loop;
+      }
+    }
+
+    stack.pop();
+  }
+
+  return false;
+}
+
+function isBound(x, y, R, C) {
+  if (x >= 0 && y >= 0 && x < R && y < C) return true;
+
+  return false;
+}

--- a/boj/gold/트리의_지름/jaeung.js
+++ b/boj/gold/트리의_지름/jaeung.js
@@ -1,0 +1,52 @@
+const fs = require("fs");
+const input = fs.readFileSync("dev/stdin").toString().trim().split("\n");
+const [[N], ...links] = input.map((str) => str.split(" ").map(Number));
+
+solution(N, links);
+
+function solution(N, links) {
+  const tree = Array.from(Array(N + 1), () => []);
+
+  links.forEach(([nodeA, nodeB, distance]) => {
+    tree[nodeA].push([nodeB, distance]);
+    tree[nodeB].push([nodeA, distance]);
+  });
+
+  const startNode = searchFarNode(1, tree);
+  const endNode = searchFarNode(startNode[0], tree);
+
+  console.log(endNode[1]);
+}
+
+function searchFarNode(rootNode, tree) {
+  const visited = Array(N + 1).fill(false);
+  const stack = [[rootNode, 0]];
+  let distance = 0;
+  let farNode = [0, 0];
+
+  visited[rootNode] = true;
+
+  loop: while (stack.length > 0) {
+    const [node, weight] = stack[stack.length - 1];
+
+    for (const [childNode, childWeight] of tree[node]) {
+      const isVisit = visited[childNode] === true;
+
+      if (!isVisit) {
+        stack.push([childNode, childWeight]);
+        visited[childNode] = true;
+        distance += childWeight;
+        continue loop;
+      }
+    }
+
+    if (distance > farNode[1]) {
+      farNode = [node, distance];
+    }
+
+    stack.pop();
+    distance -= weight;
+  }
+
+  return farNode;
+}


### PR DESCRIPTION
# 문제 출처 💻

[Two Dots](https://www.acmicpc.net/problem/16929)

# 소요 시간 ⏱

40m

# 문제 접근 방법 🤔

- 사이클은 모든 점을 기준으로 모두 확인해야 하므로, 인접행렬을 순회하며 `DFS` 탐색을 진행하는 방법으로 접근

- 사이클이 있다면 `true`, 없다면 `false`를 반환하는, `DFS` 알고리즘을 기반으로 한 `searchCycle(x, y, N, M, board)` 함수 선언
  - 시작 위치를 기준으로 상, 하, 좌, 우에 **아직 방문하지 않았고, 이전 요소와 색이 동일하다면** `stack`에 해당 요소를 추가 및 방문처리
  - 탐색 도중 **해당 좌표가 시작 좌표와 동일하고, 지금까지 탐색한 노드의 깊이가 4 이상인 경우** 사이클이 존재하므로 `true`를 반환
  - 적절한 사이클을 찾지 못한 경우, `stack`에서 요소를 하나씩 제거하며 `while` 루프 탈출, `false`를 반환

- 단 하나의 사이클이라도 존재하는 경우 `Yes`, 모든 점을 기준으로 탐색해도 사이클이 없다면 `No`를 반환하여 해결

<br><br><br><br>

# 문제 출처 💻

[트리의 지름](https://www.acmicpc.net/problem/1967)

# 소요 시간 ⏱

30m

# 문제 접근 방법 🤔

- 특정 노드로부터 가장 멀리 떨어진(가중치가 가장 높은) 노드를 기준으로, 가장 멀리 떨어진 노드 사이의 가중치를 구하면 트리의 가장 넓은 지름이 나온다는 것을 확인

- 따라서 `DFS`를 2번 진행하여 **1번 노드부터 시작하여 가장 멀리 떨어진 노드를 찾고, 다시 해당 노드를 기준으로 하여 멀리 있는 노드를 찾는 방식**으로 접근

- 1번 순회 후 기준이 되는 노드가 바뀌기 때문에, 인접 리스트는 **양방향 그래프**로 구현

- 특정 노드를 기준으로 가장 멀리 있는 노드의 번호와, 해당 노드까지의 가중치를 구하는 `searchFarNode(rootNode, tree)` 함수 구현
  - 다른 노드에 방문할 때 마다, 거리를 합산하기 위해 `distance` 변수 선언
  - 리프 노드에 도달하면 `distance`와 비교를 통해, 가장 먼 노드를 갱신하는 `farNode` 변수 선언
  - 해당 위치에서 방문 할 노드가 없다면, `stack`에서 노드를 하나씩 제거하며 `distance`에서 해당 노드의 거리만큼 뺀다
  - 모든 노드를 방문할 때 까지 위 로직을 반복하여, 가장 멀리 있는 노드와 거리의 합을 담고있는 배열을 반환

- 위 함수를 두 번 호출해서 나온 결과를 반환하여 해결(`searchFarNode(searchFarNode(1, tree)[0], tree)[1]`)

<br><br><br><br>

# 문제 출처 💻

[빵집](https://www.acmicpc.net/problem/3109)

# 소요 시간 ⏱

1h

# 문제 접근 방법 🤔

- 초기에는 **가장 위에 있는 파이프를 먼저 방문해야 가장 많은 파이프를 설치할 수 있으므로, 그리디 방식의 풀이**로 접근
  - 인접 행렬의 행을 순회하며 `DFS` 탐색을 진행하고, 파이프 설치가 가능하다면 `true`, 아니라면 `false`를 반환하는 `isPlumbing(x, visited, grids)` 함수를 구현
    - 초기 위치는 항상 `[x, 0]` 부터 시작하여, **오른쪽 위 -> 오른쪽 -> 오른쪽 아래**순서대로 탐색하기 위해 `dx, dy` 배열을 선언
    - 다음 파이프를 연결할 곳이 아직 방문하지 않았고, 건물이 아닌 빈칸이라면 `stack`에 해당 위치를 추가하고 방문처리 함
    - 아직 빵집에 파이프가 연결되지 않았고, 더 이상 방문할 곳이 없다면 `stack`에서 요소를 하나씩 제거
    - 마지막까지 정상적으로 파이프가 연결되었다면(`currentY === C - 1`) `true`, 아니라면 `false`를 반환
    
  - `isPlumbing(x, visited, grids)`의 결과가 `true`인 경우, `pipeCount`를 하나씩 증가시키고, `pipeCount`를 반환하여 해결

- `label`을 이용한 반복문과 `continue` 때문에 코드의 흐름을 파악하기 어려워서, 기존 코드를 변경(`commit log` 확인)
  - 큰 틀은 비슷하지만, 현재 위치에서 연결할 수 있는 모든 파이프를 `stack`에 추가 및 방문처리
  - 이 과정에서 기존의 **오른쪽 위 -> 오른쪽 -> 오른쪽 아래**의 우선순위가 반전되기 때문에 `dx` 배열을 적절히 수정
  - 이러한 방법은 **최적의 경로를 찾아도, 실제로 방문하지 않은 곳 까지 방문 처리가 되어있음**
  - 위 문제를 해결하기 위해 가장 최적 경로를 찾게되면, `stack`에 남아있는 좌표(경로는 찾았으나 실제로 방문하지 않은 경로)들은 방문 여부를 `false`로 다시 변경하여 해결
