### PR TITLE
[Backtracking 1주차] jaeung

### DIFF
--- a/boj/silver/N과_M(1)/jaeung.js
+++ b/boj/silver/N과_M(1)/jaeung.js
@@ -1,0 +1,48 @@
+const fs = require("fs");
+const input = fs.readFileSync("dev/stdin").toString().trim().split(" ");
+const [N, M] = input.map(Number);
+
+console.log(solution(N, M));
+
+function solution(N, M) {
+  const result = permutation(N, M).reduce(
+    (str, sequence) => (str += `${sequence.join(" ")}\n`),
+    ""
+  );
+
+  return result;
+}
+
+function permutation(length, depth) {
+  const result = [];
+  const stack = [];
+  const visited = Array(N + 1).fill(false);
+
+  for (let i = length; i >= 1; i--) {
+    stack.push([i]);
+  }
+
+  while (stack.length > 0) {
+    const sequence = stack.pop();
+
+    for (let i = 1; i <= length; i++) {
+      const isVisit = sequence.includes(i) === true;
+      visited[i] = isVisit ? true : false;
+    }
+
+    if (sequence.length === depth) {
+      result.push(sequence);
+    }
+
+    for (let i = length; i >= 1; i--) {
+      const isVisit = visited[i] === true;
+
+      if (!isVisit) {
+        stack.push([...sequence, i]);
+        visited[i] = true;
+      }
+    }
+  }
+
+  return result;
+}

--- a/boj/silver/N과_M(1)/jaeung.js
+++ b/boj/silver/N과_M(1)/jaeung.js
@@ -16,7 +16,6 @@ function solution(N, M) {
 function permutation(length, depth) {
   const result = [];
   const stack = [];
-  const visited = Array(N + 1).fill(false);
 
   for (let i = length; i >= 1; i--) {
     stack.push([i]);
@@ -24,10 +23,10 @@ function permutation(length, depth) {
 
   while (stack.length > 0) {
     const sequence = stack.pop();
+    const visited = Array(N + 1).fill(false);
 
-    for (let i = 1; i <= length; i++) {
-      const isVisit = sequence.includes(i) === true;
-      visited[i] = isVisit ? true : false;
+    for (let i = 0; i <= sequence.length; i++) {
+      visited[sequence[i]] = true;
     }
 
     if (sequence.length === depth) {

--- a/boj/silver/N과_M(1)/jaeung.js
+++ b/boj/silver/N과_M(1)/jaeung.js
@@ -39,7 +39,6 @@ function permutation(length, depth) {
 
       if (!isVisit) {
         stack.push([...sequence, i]);
-        visited[i] = true;
       }
     }
   }

--- a/boj/silver/부등호/jaeung.js
+++ b/boj/silver/부등호/jaeung.js
@@ -1,0 +1,54 @@
+const fs = require("fs");
+const input = fs.readFileSync("dev/stdin").toString().trim().split("\r\n");
+const N = +input[0];
+const inequalities = input[1].split(" ");
+
+console.log(solution(N, inequalities));
+
+function solution(N, inequalities) {
+  const RANGE = 9;
+  const [max, min] = getSequence(RANGE, inequalities, N + 1);
+
+  return `${max}\n${min}`;
+}
+
+function getSequence(range, inequalities, depth) {
+  const stack = [];
+  let maxSequence = -Infinity;
+  let minSequence = Infinity;
+
+  for (let i = range; i >= 0; i--) {
+    stack.push([i]);
+  }
+
+  while (stack.length > 0) {
+    const sequence = stack.pop();
+    const length = sequence.length;
+    const visited = Array(range + 1).fill(false);
+
+    for (let i = 0; i < length; i++) {
+      visited[sequence[i]] = true;
+    }
+
+    if (length === depth) {
+      const value = sequence.join("");
+
+      maxSequence = Math.max(maxSequence, value);
+      minSequence = Math.min(minSequence, value);
+    }
+
+    if (inequalities[length - 1] === "<") {
+      for (let i = sequence[length - 1] + 1; i <= range; i++) {
+        if (!visited[i]) stack.push([...sequence, i]);
+      }
+    }
+
+    if (inequalities[length - 1] === ">") {
+      for (let i = 0; i < sequence[length - 1]; i++) {
+        if (!visited[i]) stack.push([...sequence, i]);
+      }
+    }
+  }
+
+  return [`${maxSequence}`, String(minSequence).padStart(depth, "0")];
+}

--- a/boj/silver/스타트와_링크/jaeung.js
+++ b/boj/silver/스타트와_링크/jaeung.js
@@ -14,7 +14,7 @@ function solution(N, stats) {
     const teamLink = employee.filter((num) => !teamStart.includes(num));
     const overallStart = getTeamOverall(teamStart, stats);
     const overallLink = getTeamOverall(teamLink, stats);
-    const difference = Math.abs(overallStart, overallLink);
+    const difference = Math.abs(overallStart - overallLink);
 
     minDifference = Math.min(minDifference, difference);
   }
@@ -61,7 +61,6 @@ function getTeamOverall(team, stats) {
 
   for (let i = 0; i < team.length; i++) {
     for (let j = 0; j < team.length; j++) {
-      console.log(team, team[i] - 1, team[j] - 1);
       overall += stats[team[i] - 1][team[j] - 1];
     }
   }

--- a/boj/silver/스타트와_링크/jaeung.js
+++ b/boj/silver/스타트와_링크/jaeung.js
@@ -1,0 +1,70 @@
+const fs = require("fs");
+const input = fs.readFileSync("dev/stdin").toString().trim().split("\r\n");
+const [[N], ...stats] = input.map((str) => str.split(" ").map(Number));
+
+console.log(solution(N, stats));
+
+function solution(N, stats) {
+  const employee = Array.from(Array(N), (_, i) => ++i);
+  const teamList = combination(N, N / 2);
+  let minDifference = Infinity;
+
+  for (let i = 0; i < teamList.length; i++) {
+    const teamStart = teamList[i];
+    const teamLink = employee.filter((num) => !teamStart.includes(num));
+    const overallStart = getTeamOverall(teamStart, stats);
+    const overallLink = getTeamOverall(teamLink, stats);
+    const difference = Math.abs(overallStart, overallLink);
+
+    minDifference = Math.min(minDifference, difference);
+  }
+
+  return minDifference;
+}
+
+function combination(length, depth) {
+  const result = [];
+  const stack = [];
+  const visited = Array(length + 1).fill(false);
+
+  for (let i = length; i >= 1; i--) {
+    stack.push([i]);
+  }
+
+  while (stack.length > 0) {
+    const sequence = stack.pop();
+    const max = Math.max(...sequence);
+
+    for (let i = 1; i <= length; i++) {
+      visited[i] = i <= max ? true : false;
+    }
+
+    if (depth === sequence.length) {
+      result.push(sequence);
+    }
+
+    for (let i = length; i >= sequence[0]; i--) {
+      const isVisit = visited[i] === true;
+
+      if (!isVisit) {
+        stack.push([...sequence, i]);
+        visited[i] = true;
+      }
+    }
+  }
+
+  return result;
+}
+
+function getTeamOverall(team, stats) {
+  let overall = 0;
+
+  for (let i = 0; i < team.length; i++) {
+    for (let j = 0; j < team.length; j++) {
+      console.log(team, team[i] - 1, team[j] - 1);
+      overall += stats[team[i] - 1][team[j] - 1];
+    }
+  }
+
+  return overall;
+}

--- a/boj/silver/스타트와_링크/jaeung.js
+++ b/boj/silver/스타트와_링크/jaeung.js
@@ -34,10 +34,7 @@ function getDifferenceMinimum(length, depth, stats) {
     for (let i = length; i >= sequence[0]; i--) {
       const isVisit = visited[i] === true;
 
-      if (!isVisit) {
-        stack.push([...sequence, i]);
-        visited[i] = true;
-      }
+      if (!isVisit) stack.push([...sequence, i]);
     }
   }
 

--- a/boj/silver/스타트와_링크/jaeung.js
+++ b/boj/silver/스타트와_링크/jaeung.js
@@ -1,37 +1,25 @@
 const fs = require("fs");
-const input = fs.readFileSync("dev/stdin").toString().trim().split("\r\n");
+const input = fs.readFileSync("dev/stdin").toString().trim().split("\n");
 const [[N], ...stats] = input.map((str) => str.split(" ").map(Number));
 
 console.log(solution(N, stats));
 
 function solution(N, stats) {
-  const employee = Array.from(Array(N), (_, i) => ++i);
-  const teamList = combination(N, N / 2);
-  let minDifference = Infinity;
-
-  for (let i = 0; i < teamList.length; i++) {
-    const teamStart = teamList[i];
-    const teamLink = employee.filter((num) => !teamStart.includes(num));
-    const overallStart = getTeamOverall(teamStart, stats);
-    const overallLink = getTeamOverall(teamLink, stats);
-    const difference = Math.abs(overallStart - overallLink);
-
-    minDifference = Math.min(minDifference, difference);
-  }
-
-  return minDifference;
+  return getDifferenceMinimum(N, N / 2, stats);
 }
 
-function combination(length, depth) {
-  const result = [];
+function getDifferenceMinimum(length, depth, stats) {
   const stack = [];
   const visited = Array(length + 1).fill(false);
+  let minDifference = Infinity;
 
   for (let i = length; i >= 1; i--) {
     stack.push([i]);
   }
 
   while (stack.length > 0) {
+    if (minDifference === 0) return 0;
+
     const sequence = stack.pop();
     const max = Math.max(...sequence);
 
@@ -40,7 +28,7 @@ function combination(length, depth) {
     }
 
     if (depth === sequence.length) {
-      result.push(sequence);
+      minDifference = Math.min(minDifference, getDifference(sequence, stats));
     }
 
     for (let i = length; i >= sequence[0]; i--) {
@@ -53,17 +41,21 @@ function combination(length, depth) {
     }
   }
 
-  return result;
+  return minDifference;
 }
 
-function getTeamOverall(team, stats) {
-  let overall = 0;
+function getDifference(teamStart, stats) {
+  const employee = Array.from(Array(N), (_, i) => ++i);
+  const teamLink = employee.filter((num) => !teamStart.includes(num));
+  let scoreStart = 0,
+    scoreLink = 0;
 
-  for (let i = 0; i < team.length; i++) {
-    for (let j = 0; j < team.length; j++) {
-      overall += stats[team[i] - 1][team[j] - 1];
+  for (let i = 0; i < teamStart.length; i++) {
+    for (let j = 0; j < teamStart.length; j++) {
+      scoreStart += stats[teamStart[i] - 1][teamStart[j] - 1];
+      scoreLink += stats[teamLink[i] - 1][teamLink[j] - 1];
     }
   }
 
-  return overall;
+  return Math.abs(scoreStart - scoreLink);
 }

--- a/boj/silver/스타트와_링크/jaeung.js
+++ b/boj/silver/스타트와_링크/jaeung.js
@@ -21,7 +21,7 @@ function getDifferenceMinimum(length, depth, stats) {
     if (minDifference === 0) return 0;
 
     const sequence = stack.pop();
-    const max = Math.max(...sequence);
+    const max = sequence[sequence.length - 1];
 
     for (let i = 1; i <= length; i++) {
       visited[i] = i <= max ? true : false;


### PR DESCRIPTION
# 궁금해요 😏

문제를 풀다 보면 하나의 파일에 이미 전역 상수로 정의되어 있는 것을, 어떤 함수가 다른 함수를 호출할 때 인자로 넘겨줘야 하는 경우가 자주 생기는 것 같습니다.

예시로 **스타트와 링크** 풀이에서 `stats`가 그러한데요, 아래처럼 정작 `getDifferenceMinimum(length, depth, stats)` 함수에서는 `stats`를 사용하지 않는데도 불구하고, 단지 `getDifference(teamStart, stats)`에게 전달해주기 위해서 인수로 받고 있습니다.

```javascript
...
function getDifferenceMinimum(length, depth, stats) {
  // stats를 사용하지 않음
  ...
      minDifference = Math.min(minDifference, getDifference(sequence, stats));
  ...
}

function getDifference(teamStart, stats) {
  // stats 사용
  ...
}
```

이러한 상황이 마치 컴포넌트에서 일어날 수 있는 `Prop Drilling`과 유사해 보이는데, 이런 경우 ***'하나의 파일에서 전역적으로 쓰이는 상수는 굳이 다른 함수에 인자로 전달해줄 필요가 없는 게 아닌가?'*** 싶은데요, 민종님의 의견은 어떠신지 여쭤보고 싶습니다! 🙇‍♂️

<br><br>


# 문제 출처 💻

[N과 M(1)](https://www.acmicpc.net/problem/15649)

# 소요 시간 ⏱

50m

# 문제 접근 방법 🤔

- 순열 알고리즘 문제. 재귀를 사용하지 않고, `stack`을 이용해 구현하는 쪽으로 접근

- 모든 요소는 순서를 유지하기 위해, `stack`에 역순으로 추가(`4 -> 3 -> 2 ->1`)

- 매 루프마다 `stack`에 있는 배열(수열)을 하나 꺼내고, 해당 번호를 방문하지 않았다면 마지막에 꺼낸 배열의 마지막에 번호를 추가한 뒤 `stack`에 새로운 수열을 삽입 (`ex) [1] -> [1, 4], [1, 3], [1, 2]`)

- 방문 처리는 `stack`에서 꺼낸 수열을 순회하며, 각 번호에 해당하는 `visited` 배열의 `index`를 `true`로 변경

- `stack`에서 꺼낸 수열의 길이가 깊이와 일치하면, `result`에 해당 수열을 추가

- `result` 배열을 순회하며 요구사항에 맞게 출력하여 해결

<br><br><br><br>

# 문제 출처 💻

[스타트와 링크](https://www.acmicpc.net/problem/14889)

# 소요 시간 ⏱

1h+

# 문제 접근 방법 🤔

- 처음 풀이는 조합 알고리즘을 구현하고, 반환된 조합을 이용해서 총 팀원의 능력치를 합산하는 방식으로 접근

  - `stack`을 이용해서  조합 알고리즘을 구현
    - 순열 알고리즘과 마찬가지로 수열을 `stack`에 배열 형태로 저장
    - 순열과 차이점은 새로운 수열 추가 시, 항상 수열의 첫 번째 번호보다 높은 번호만 추가하도록 함(중복 제거)
    - 마찬가지로 중복을 제거하기 위해서, 매 루프마다 수열의 가장 마지막 번호보다 작은 번호들은 모두 방문처리
 
  - 총 인원을 절반으로 나누어서 팀을 구성하므로, 조합은 번호의 크기가 `N`이고, 최대 깊이는 `N / 2`로 구성됨
  - 조합 알고리즘으로 반환된 배열을 순회하며 아래 로직을 수행
    - 조합으로 발견한 배열은 `teamA`, 해당 조합에 없는 번호로만 이루어진 배열을 `teamB`로 구분
    - 두 팀 배열을 각각 순회하며 능력치의 총 합을 계산
    - `Math.abs()` 메서드를 이용해서 두 팀의 능력치 차이를 계산하고, `Math.min()` 메서드로 최소 능력치를 갱신
  - 이후 최소 차이를 반환하여 해결
  
- 하지만 위의 방법은 **조합을 다 구한 뒤, 다시 순회하면서 능력치를 계산하기 때문에 비효율적**이라고 판단. 백트래킹의 취지에 맞게 조합을 구성하다가, 특정 깊이에 도달하면 능력치를 계산하는 식으로 수정

- 조합된 배열을 따로 저장해두지 않기 때문에 공간 복잡도는 1/5 수준으로 줄었지만, 시간 복잡도가 조금 늘어났다.
![image](https://user-images.githubusercontent.com/62253743/200161612-364f9799-a906-4f0b-817c-53890926d591.png)

<br><br><br><br>

# 문제 출처 💻

[부등호](https://www.acmicpc.net/problem/2529)

# 소요 시간 ⏱

30m

# 문제 접근 방법 🤔

- N과 M (1) 문제와 마찬가지로, 순열 알고리즘을 이용한 풀이로 접근

- 순열 알고리즘을 이용해서 최대 크기의 수열과, 최소 크기의 수열을 반환하는 `getSequence(range, inequalities, depth)`함수 구현
  - 최대 값과 최소 값을 담아두는 변수(`maxSequence`, `minSequence`)를 선언
  - 기존 순열 알고리즘과 다르게, 부등호의 방향에 따라서 조건을 만족하는 값만 추가하도록 구현
  - 특정 깊이에 도달하면, 해당 수열을 `String.join()`을 이용해 문자열로 만든 뒤, 최대 및 최소값과 비교하여 갱신
  - 최소값의 경우 비교하는 과정에서 `0`이 제거되기 때문에, `String.padStart()` 메서드로 0을 추가
  - 출력 조건에 맞춰서 두 값 모두 문자열 형태로 반환
 
- 이후 `getSequence()`로 반환된 문자열을 출력하여 해결