### PR TITLE
[Dijkstra 1주차] jaeung

### DIFF
--- a/boj/silver/지름길/jaeung.js
+++ b/boj/silver/지름길/jaeung.js
@@ -1,5 +1,5 @@
 const fs = require("fs");
-const input = fs.readFileSync("dev/stdin").toString().trim().split("\r\n");
+const input = fs.readFileSync("dev/stdin").toString().trim().split("\n");
 const [[N, D], ...edge] = input.map((str) => str.split(" ").map(Number));
 
 console.log(solution());
@@ -30,8 +30,10 @@ function getMinDistance(graph) {
     if (i > 0) distance[i] = Math.min(distance[i], prevDistance + 1);
 
     graph[i].forEach(([nextDistance, weight]) => {
-      if (distance[nextDistance] > distance[i] + weight)
-        distance[nextDistance] = distance[i] + weight;
+      distance[nextDistance] = Math.min(
+        distance[nextDistance],
+        distance[i] + weight
+      );
     });
   }
 

--- a/boj/silver/지름길/jaeung.js
+++ b/boj/silver/지름길/jaeung.js
@@ -1,0 +1,39 @@
+const fs = require("fs");
+const input = fs.readFileSync("dev/stdin").toString().trim().split("\r\n");
+const [[N, D], ...distance] = input.map((str) => str.split(" ").map(Number));
+
+console.log(solution());
+
+function solution() {
+  const graph = Array.from({ length: D + 1 }, () => []);
+
+  for (let i = 0; i < N; i++) {
+    const [from, to, weight] = distance[i];
+
+    if (to > D) continue;
+    if (to - from <= weight) continue;
+
+    graph[from].push([to, weight]);
+  }
+
+  return getMinDistance(graph);
+}
+
+function getMinDistance(graph) {
+  const distance = Array(D + 1).fill(Infinity);
+
+  distance[0] = 0;
+
+  for (let i = 0; i <= D; i++) {
+    const prevDistance = distance[i - 1];
+
+    if (i > 0) distance[i] = Math.min(distance[i], prevDistance + 1);
+
+    graph[i].forEach(([nextDistance, weight]) => {
+      if (distance[nextDistance] > distance[i] + weight)
+        distance[nextDistance] = distance[i] + weight;
+    });
+  }
+
+  return distance[D];
+}

--- a/boj/silver/지름길/jaeung.js
+++ b/boj/silver/지름길/jaeung.js
@@ -1,6 +1,6 @@
 const fs = require("fs");
 const input = fs.readFileSync("dev/stdin").toString().trim().split("\r\n");
-const [[N, D], ...distance] = input.map((str) => str.split(" ").map(Number));
+const [[N, D], ...edge] = input.map((str) => str.split(" ").map(Number));
 
 console.log(solution());
 
@@ -8,7 +8,7 @@ function solution() {
   const graph = Array.from({ length: D + 1 }, () => []);
 
   for (let i = 0; i < N; i++) {
-    const [from, to, weight] = distance[i];
+    const [from, to, weight] = edge[i];
 
     if (to > D) continue;
     if (to - from <= weight) continue;

--- a/boj/silver/특정_거리의_도시_찾기/jaeung.js
+++ b/boj/silver/특정_거리의_도시_찾기/jaeung.js
@@ -1,6 +1,34 @@
 const fs = require("fs");
-const input = fs.readFileSync("dev/stdin").toString().trim().split("\r\n");
+const input = fs.readFileSync("dev/stdin").toString().trim().split("\n");
 const [N, M, K, X] = input[0].split(" ").map(Number);
+class Queue {
+  constructor() {
+    this.front = 0;
+    this.rear = 0;
+    this.storage = [];
+  }
+
+  size() {
+    return this.rear - this.front;
+  }
+
+  enqueue(value) {
+    this.storage[this.rear++] = value;
+  }
+
+  dequeue() {
+    const value = this.storage[this.front];
+    delete this.storage[this.front];
+
+    if (this.size() > 0) this.front++;
+
+    return value;
+  }
+
+  display() {
+    console.log([...this.storage]);
+  }
+}
 
 console.log(solution());
 
@@ -12,40 +40,32 @@ function solution() {
 
     if (!graph[from]) graph[from] = [];
 
-    graph[+from].push([+to, 1]);
+    graph[+from].push(+to);
   }
 
-  const answer = dijkstra(X, graph);
+  const answer = getDistance(X, graph);
 
-  return answer !== "" ? answer : -1;
+  return answer === "" ? -1 : answer;
 }
 
-function dijkstra(startNode, graph) {
-  const distance = Array(N + 1).fill(Infinity);
-  const visited = Array(N + 1).fill(false);
+function getDistance(startNode, graph) {
   let result = "";
+  const distance = Array(N + 1).fill(Infinity);
+  const queue = new Queue();
+  queue.enqueue(startNode);
 
-  graph[startNode].forEach(([node, weight]) => {
-    distance[node] = weight;
-  });
+  distance[startNode] = 0;
 
-  visited[startNode] = true;
+  while (queue.size() > 0) {
+    const node = queue.dequeue();
+    if (!graph[node]) continue;
 
-  while (true) {
-    const nextIndex = getMinIndex(distance, visited, graph);
-    const arr = graph[nextIndex];
-
-    visited[nextIndex] = true;
-
-    if (nextIndex === 0) break;
-
-    for (let i = 0; i < arr.length; i++) {
-      const [node, weight] = arr[i];
-      const nextWeight = distance[nextIndex] + weight;
-      const isVisit = visited[node];
-
-      if (nextWeight < distance[node] && !isVisit) distance[node] = nextWeight;
-    }
+    graph[node].forEach((nextNode) => {
+      if (distance[nextNode] === Infinity) {
+        distance[nextNode] = distance[node] + 1;
+        queue.enqueue(nextNode);
+      }
+    });
   }
 
   distance.forEach((value, index) => {
@@ -53,18 +73,4 @@ function dijkstra(startNode, graph) {
   });
 
   return result;
-}
-
-function getMinIndex(distance, visited, graph) {
-  let min = Infinity;
-  let index = 0;
-
-  for (let i = 1; i <= N; i++) {
-    if (distance[i] < min && !visited[i] && graph[i]) {
-      min = distance[i];
-      index = i;
-    }
-  }
-
-  return index;
 }

--- a/boj/silver/특정_거리의_도시_찾기/jaeung.js
+++ b/boj/silver/특정_거리의_도시_찾기/jaeung.js
@@ -1,9 +1,65 @@
 const fs = require("fs");
 const input = fs.readFileSync("dev/stdin").toString().trim().split("\r\n");
-const [[N, M, K, X], ...edge] = input.map((str) => str.split(" ").map(Number));
+const [[N, _, K, X], ...edge] = input.map((str) => str.split(" ").map(Number));
 
-solution();
+console.log(solution());
 
 function solution() {
-  console.log(N, M, K, X, ...edge);
+  const graph = Array.from({ length: N + 1 }, (_, i) =>
+    Array(N + 1).fill(Infinity)
+  );
+
+  for (let i = 1; i <= N; i++) {
+    graph[i][i] = 0;
+  }
+
+  edge.forEach(([from, to]) => {
+    graph[from][to] = 1;
+  });
+
+  const answer = dijkstra(X, graph);
+
+  return answer !== "" ? answer : -1;
+}
+
+function dijkstra(startNode, graph) {
+  const distance = [...graph[startNode]];
+  const visited = Array(N + 1).fill(false);
+  let result = "";
+
+  visited[startNode] = true;
+
+  while (true) {
+    const nextIndex = getMinIndex(distance, visited);
+    visited[nextIndex] = true;
+
+    if (nextIndex === 0) break;
+
+    for (let i = 1; i <= N; i++) {
+      const nextWeight = distance[nextIndex] + graph[nextIndex][i];
+      const isVisit = visited[i];
+
+      if (nextWeight < distance[i] && !isVisit) distance[i] = nextWeight;
+    }
+  }
+
+  distance.forEach((value, index) => {
+    if (value === K) result += `${index}\n`;
+  });
+
+  return result;
+}
+
+function getMinIndex(distance, visited) {
+  let min = Infinity;
+  let index = 0;
+
+  for (let i = 1; i <= N; i++) {
+    if (distance[i] < min && !visited[i]) {
+      min = distance[i];
+      index = i;
+    }
+  }
+
+  return index;
 }

--- a/boj/silver/특정_거리의_도시_찾기/jaeung.js
+++ b/boj/silver/특정_거리의_도시_찾기/jaeung.js
@@ -1,0 +1,9 @@
+const fs = require("fs");
+const input = fs.readFileSync("dev/stdin").toString().trim().split("\r\n");
+const [[N, M, K, X], ...edge] = input.map((str) => str.split(" ").map(Number));
+
+solution();
+
+function solution() {
+  console.log(N, M, K, X, ...edge);
+}

--- a/boj/silver/특정_거리의_도시_찾기/jaeung.js
+++ b/boj/silver/특정_거리의_도시_찾기/jaeung.js
@@ -1,21 +1,19 @@
 const fs = require("fs");
 const input = fs.readFileSync("dev/stdin").toString().trim().split("\r\n");
-const [[N, _, K, X], ...edge] = input.map((str) => str.split(" ").map(Number));
+const [N, M, K, X] = input[0].split(" ").map(Number);
 
 console.log(solution());
 
 function solution() {
-  const graph = Array.from({ length: N + 1 }, (_, i) =>
-    Array(N + 1).fill(Infinity)
-  );
+  const graph = {};
 
-  for (let i = 1; i <= N; i++) {
-    graph[i][i] = 0;
+  for (let i = 1; i <= M; i++) {
+    const [from, to] = input[i].split(" ");
+
+    if (!graph[from]) graph[from] = [];
+
+    graph[+from].push([+to, 1]);
   }
-
-  edge.forEach(([from, to]) => {
-    graph[from][to] = 1;
-  });
 
   const answer = dijkstra(X, graph);
 
@@ -23,23 +21,30 @@ function solution() {
 }
 
 function dijkstra(startNode, graph) {
-  const distance = [...graph[startNode]];
+  const distance = Array(N + 1).fill(Infinity);
   const visited = Array(N + 1).fill(false);
   let result = "";
+
+  graph[startNode].forEach(([node, weight]) => {
+    distance[node] = weight;
+  });
 
   visited[startNode] = true;
 
   while (true) {
-    const nextIndex = getMinIndex(distance, visited);
+    const nextIndex = getMinIndex(distance, visited, graph);
+    const arr = graph[nextIndex];
+
     visited[nextIndex] = true;
 
     if (nextIndex === 0) break;
 
-    for (let i = 1; i <= N; i++) {
-      const nextWeight = distance[nextIndex] + graph[nextIndex][i];
-      const isVisit = visited[i];
+    for (let i = 0; i < arr.length; i++) {
+      const [node, weight] = arr[i];
+      const nextWeight = distance[nextIndex] + weight;
+      const isVisit = visited[node];
 
-      if (nextWeight < distance[i] && !isVisit) distance[i] = nextWeight;
+      if (nextWeight < distance[node] && !isVisit) distance[node] = nextWeight;
     }
   }
 
@@ -50,12 +55,12 @@ function dijkstra(startNode, graph) {
   return result;
 }
 
-function getMinIndex(distance, visited) {
+function getMinIndex(distance, visited, graph) {
   let min = Infinity;
   let index = 0;
 
   for (let i = 1; i <= N; i++) {
-    if (distance[i] < min && !visited[i]) {
+    if (distance[i] < min && !visited[i] && graph[i]) {
       min = distance[i];
       index = i;
     }


### PR DESCRIPTION
# 문제 출처 💻

[특정 거리의 도시 찾기](https://www.acmicpc.net/problem/18352)

# 소요 시간 ⏱

1h+

# 문제 접근 방법 🤔

- 초기에는 인접 행렬을 이용한 전형적인 다익스트라 알고리즘을 구현하는 방식으로 접근, 메모리 초과로 실패.

- `input`이 너무 큰 것이 원인으로, 인접 리스트를 이용하도록 변경, 마찬가지로 간선이 너무 많은 케이스가 있는지 시간 초과로 실패.

- 모든 도시의 가중치가 1로 동일한 것을 확인하고 `BFS`를 이용해서 구현하려 했으나, 마찬가지로 간선의 수가 많은 케이스 때문인지 `Array.shift()`의 성능 이슈로 예상되는 시간 초과로 실패.
  - `BFS` 로직은 단순하게 거리 정보를 담는 배열을 만들고, 인접 정점을 방문하면서 `이전 거리 + 1`을 통해 순차적으로 거리 정보를 담는다.
  - 이후 해당 배열에서 `K`와 일치하는 노드만 남기고, 해당 배열의 길이를 기준으로 조건에 맞춰 적절한 값을 반환하도록 구현
 
- 간단하게 `Queue` 를 구현하고, 위에서 활용한 로직에 `Array.shift()` 대신 사용했더니 해결되었다.


<br><br><br><br>

# 문제 출처 💻

[지름길](https://www.acmicpc.net/problem/1446)

# 소요 시간 ⏱

1h

# 문제 접근 방법 🤔

- 마찬가지로 `input`의 길이가 `10000`이나 되기 때문에, 인접 행렬로 구현 시 메모리 초과가 날 것으로 예상하여 인접 리스트를 활용한 다익스트라 알고리즘으로 구현하려고 했다.

- 하지만 이전 문제와는 다르게 자동차가 1씩 움직일 때 마다 (매 정점마다) 다익스트라를 적용해야 하는데, 이런 경우 우선 순위 큐를 구현해야 하기 때문에 좀 더 쉬운 방법을 고민.

- 다익스트라 또한 DP를 응용한 알고리즘 이지만, 이 문제의 경우 DP만으로도 풀 수 있을 것 같아서 DP로 해결하는 쪽으로 접근
  - 먼저 인접 리스트에 `도착 거리가 총 거리보다 크거나`,  `지름길이 있는 거리가 지름길보다 긴 경우`를 **제외하고** `graph` 배열에 저장해서 미리 조건을 좁혀둔다.
  
  - 모든 정점의 거리 정보를 담고있는 `distance` 배열을 선언
  - 이후 `0`부터 시작하여 `D`까지 1씩 증가시키며 이전 거리에 1을 더한 값과, 현재 거리를 비교하여 더 작은 값을 `distance[index]`에 갱신
  - 위 로직을 반복하다 간선 정보가 있는 거리에 도달하면(지름길의 유무), `graph[nextDistance]` 배열을 순회하며 더 짧은 지름길을 `distance[nextDistance]`에 갱신
  
- 최종적으로 `distance[D]`에 있는 거리를 반환하여 해결